### PR TITLE
chore: librarian release pull request: 20260120T183915Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:d2dee66d7c8c1d673fac26280164ea24015b79491b7f9d6ba369e6a98ab3420c
 libraries:
   - id: compute
-    version: 1.54.0-preview.1
+    version: 1.54.0-preview.2
     last_generated_commit: 796e0498a680b69e190cea73433eae522e74578a
     apis:
       - path: google/cloud/compute/v1

--- a/compute/CHANGES.md
+++ b/compute/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## [1.54.0-preview.2](https://github.com/googleapis/google-cloud-go/releases/tag/compute%2Fv1.54.0-preview.2) (2026-01-20)
+
+### Features
+
+* generate libraries (#4) ([d18322a](https://github.com/googleapis/google-cloud-go/commit/d18322a9c017a3c6044c265af0e226a3c28c93a8))
+
 ## [1.53.0](https://github.com/googleapis/google-cloud-go/releases/tag/compute%2Fv1.53.0) (2026-01-08)
 
 ### Features

--- a/compute/internal/version.go
+++ b/compute/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.53.0"
+const Version = "1.54.0-preview.2"

--- a/internal/generated/snippets/compute/apiv1/snippet_metadata.google.cloud.compute.v1.json
+++ b/internal/generated/snippets/compute/apiv1/snippet_metadata.google.cloud.compute.v1.json
@@ -1,7 +1,7 @@
 {
   "clientLibrary": {
     "name": "cloud.google.com/go/compute/apiv1",
-    "version": "1.54.0-preview.1",
+    "version": "1.54.0-preview.2-preview.1",
     "language": "GO",
     "apis": [
       {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.2-0.20260120160844-290dd0ced8e4
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:d2dee66d7c8c1d673fac26280164ea24015b79491b7f9d6ba369e6a98ab3420c
<details><summary>compute: 1.54.0-preview.2</summary>

## [1.54.0-preview.2](https://github.com/noahdietz/google-cloud-go/compare/compute/v1.54.0-preview.1...compute/v1.54.0-preview.2) (2026-01-20)

### Features

* generate libraries (#4) ([d18322a9](https://github.com/noahdietz/google-cloud-go/commit/d18322a9))

</details>