### PR TITLE
chore: librarian release pull request: 20260408T174904Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,3 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
 libraries:
   - id: accessapproval
@@ -434,9 +447,7 @@ libraries:
     last_generated_commit: ""
     apis:
       - path: google/cloud/biglake/v1
-        service_config: ""
       - path: google/cloud/biglake/hive/v1beta
-        service_config: ""
     source_roots:
       - biglake
       - internal/generated/snippets/biglake
@@ -898,7 +909,6 @@ libraries:
       - path: google/cloud/datacatalog/v1beta1
         service_config: datacatalog_v1beta1.yaml
       - path: google/cloud/datacatalog/lineage/configmanagement/v1
-        service_config: ""
     source_roots:
       - datacatalog
       - internal/generated/snippets/datacatalog
@@ -1701,7 +1711,6 @@ libraries:
       - path: google/maps/solar/v1
         service_config: solar_v1.yaml
       - path: google/maps/geocode/v4
-        service_config: ""
     source_roots:
       - maps
       - internal/generated/snippets/maps
@@ -1961,7 +1970,6 @@ libraries:
     last_generated_commit: ""
     apis:
       - path: google/cloud/orgpolicy/v1
-        service_config: ""
       - path: google/cloud/orgpolicy/v2
         service_config: orgpolicy_v2.yaml
     source_roots:
@@ -2003,7 +2011,6 @@ libraries:
       - path: google/cloud/oslogin/v1beta
         service_config: oslogin_v1beta.yaml
       - path: google/cloud/oslogin/common
-        service_config: ""
     source_roots:
       - oslogin
       - internal/generated/snippets/oslogin
@@ -2352,7 +2359,7 @@ libraries:
       - internal/generated/snippets/scheduler/
     tag_format: '{id}/v{version}'
   - id: secretmanager
-    version: 1.17.0
+    version: 1.18.0
     last_generated_commit: ""
     apis:
       - path: google/cloud/secretmanager/v1
@@ -2594,7 +2601,6 @@ libraries:
       - path: google/shopping/merchant/reviews/v1beta
         service_config: merchantapi_v1beta.yaml
       - path: google/shopping/type
-        service_config: ""
     source_roots:
       - shopping
       - internal/generated/snippets/shopping

--- a/internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json
+++ b/internal/generated/snippets/secretmanager/apiv1/snippet_metadata.google.cloud.secretmanager.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/secretmanager/apiv1",
-    "version": "1.17.0"
+    "version": "1.18.0"
   },
   "snippets": [
     {

--- a/internal/generated/snippets/secretmanager/apiv1beta2/snippet_metadata.google.cloud.secretmanager.v1beta2.json
+++ b/internal/generated/snippets/secretmanager/apiv1beta2/snippet_metadata.google.cloud.secretmanager.v1beta2.json
@@ -8,7 +8,7 @@
     ],
     "language": "GO",
     "name": "cloud.google.com/go/secretmanager/apiv1beta2",
-    "version": "1.17.0"
+    "version": "1.18.0"
   },
   "snippets": [
     {

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1052,7 +1052,7 @@ libraries:
       - path: google/cloud/scheduler/v1
       - path: google/cloud/scheduler/v1beta1
   - name: secretmanager
-    version: 1.17.0
+    version: 1.18.0
     apis:
       - path: google/cloud/secretmanager/v1
       - path: google/cloud/secretmanager/v1beta2

--- a/secretmanager/CHANGES.md
+++ b/secretmanager/CHANGES.md
@@ -2,6 +2,8 @@
 
 
 
+## [1.18.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.18.0) (2026-04-08)
+
 ## [1.17.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.17.0) (2026-04-02)
 
 ## [1.16.0](https://github.com/googleapis/google-cloud-go/releases/tag/secretmanager%2Fv1.16.0) (2025-10-16)

--- a/secretmanager/internal/version.go
+++ b/secretmanager/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "1.17.0"
+const Version = "1.18.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.10.1-0.20260408162740-399e2ccbf6bb
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:b04b076f5eedbb5546bd6fc1404969dd3698c8b19c0f34ae815a84ae735a606a
<details><summary>secretmanager: v1.18.0</summary>

## [v1.18.0](https://github.com/noahdietz/google-cloud-go/compare/secretmanager/v1.17.0...secretmanager/v1.18.0) (2026-04-08)

</details>